### PR TITLE
Make `curry` preserve argument order when arity > 2.

### DIFF
--- a/lib/sky.ex
+++ b/lib/sky.ex
@@ -26,7 +26,6 @@ defmodule Sky do
   defp curried(f, args, arity) when length(args) == arity do
     apply(f, Enum.reverse(args))
   end
-
   defp curried(f, args, arity) do
     fn x -> curried(f, [x | args], arity) end
   end

--- a/lib/sky.ex
+++ b/lib/sky.ex
@@ -20,15 +20,15 @@ defmodule Sky do
     6
   """
   def curry(f, given \\ []) when is_function(f) do
-    n = arity(f)
+    curried(f, Enum.reverse(given), arity(f))
+  end
 
-    if length(given) == n do
-      apply(f, given)
-    else
-      fn x ->
-        curry(f, Enum.reverse([x|given]))
-      end
-    end
+  defp curried(f, args, arity) when length(args) == arity do
+    apply(f, Enum.reverse(args))
+  end
+
+  defp curried(f, args, arity) do
+    fn x -> curried(f, [x | args], arity) end
   end
 
   @doc """

--- a/test/sky_test.exs
+++ b/test/sky_test.exs
@@ -6,6 +6,12 @@ defmodule SkyTest do
   # the doctests, let's focus on composing
   # this library's functions.
 
+  test "curry preserves argument order" do
+    assert [1, 2, 3, 4] ==
+      Sky.curry(fn(a, b, c, d) -> [a, b, c, d] end).
+      (1).(2).(3).(4)
+  end
+
   test "compose a safe float division" do
     safe_float_div =
       fn(a, b) -> a / b end


### PR DESCRIPTION
Previous curry implementation was not preserving argument order.

```elixir
iex> Sky.curry(fn(a, b, c, d) -> [a, b, c, d] end).(1).(2).(3).(4)
[3, 1, 2, 4] # wrong
```