### PR TITLE
Improve docstrings.

### DIFF
--- a/lib/sky.ex
+++ b/lib/sky.ex
@@ -1,23 +1,22 @@
 defmodule Sky do
-  @moduledoc """
-  Collection of higher-oder functions
-  not present in the standard library.
+  @moduledoc ~S"""
+  Collection of higher-oder functions not present in the standard library.
   """
 
-  @doc """
+  @doc ~S"""
   Curries the given function, starting with an optional list of given params.
 
   ## Examples
 
   The order of the arguments is respected.
 
-    iex> Sky.curry(fn(a, b) -> a - b end).(5).(4)
-    1
+      iex> Sky.curry(fn(a, b) -> a - b end).(5).(4)
+      1
 
   You can also pass it a list of predefined parameters.
 
-    iex> Sky.curry(fn(a, b, c) -> a + b + c end, [1, 2]).(3)
-    6
+      iex> Sky.curry(fn(a, b, c) -> a + b + c end, [1, 2]).(3)
+      6
   """
   def curry(f, given \\ []) when is_function(f) do
     n = arity(f)
@@ -31,14 +30,14 @@ defmodule Sky do
     end
   end
 
-  @doc """
+  @doc ~S"""
   Given a function *f* with arity *n*, return a function that receives a
   single tuple of *n* elements and applies them to the original *f*.
 
   ## Example
 
-    iex> Sky.tupleize(fn(a, b) -> a + b end).({1, 2})
-    3
+      iex> Sky.tupleize(fn(a, b) -> a + b end).({1, 2})
+      3
 
   It might seem less useful for functions of one argument, but you might
   gain composability with other functions from the module.
@@ -51,7 +50,7 @@ defmodule Sky do
     end
   end
 
-  @doc """
+  @doc ~S"""
   Given a *single-argument* function *f*, return a new function that
   receives either a tuple in the form `{:ok, value}` which would execute
   `f.(value)`, or any other term, which would be returned without change.
@@ -62,17 +61,17 @@ defmodule Sky do
 
   ## Example
 
-    iex> inc = Sky.lift_ok(fn n -> n + 1 end)
-    iex> inc.({:ok, 1})
-    {:ok, 2}
-    iex> inc.({:error, :bad_input})
-    {:error, :bad_input}
+      iex> inc = Sky.lift_ok(fn n -> n + 1 end)
+      iex> inc.({:ok, 1})
+      {:ok, 2}
+      iex> inc.({:error, :bad_input})
+      {:error, :bad_input}
 
   Note that the value is always a two-element tuple `{:ok, v}`.
 
-    iex> inc = Sky.lift_ok(fn n -> n + 1 end)
-    iex> inc.(inc.({:ok, 1}))
-    {:ok, 3}
+      iex> inc = Sky.lift_ok(fn n -> n + 1 end)
+      iex> inc.(inc.({:ok, 1}))
+      {:ok, 3}
 
   """
   def lift_ok(f) when is_function(f) do
@@ -85,33 +84,33 @@ defmodule Sky do
   defp flatten({:ok, value}), do: flatten(value)
   defp flatten(value), do: {:ok, value}
 
-  @doc """
+  @doc ~S"""
   Given a two argument functions, swap the order in wich the arguments
   are received.
 
   ## Examples
 
-    iex> Sky.swap(&rem/2).(7, 5)
-    5
+      iex> Sky.swap(&rem/2).(7, 5)
+      5
 
-    iex> Sky.swap(fn(a, b) -> a - b end).(2, 1)
-    -1
+      iex> Sky.swap(fn(a, b) -> a - b end).(2, 1)
+      -1
   """
   def swap(f) when is_function(f) do
     fn(a, b) -> f.(b, a) end
   end
 
-  @doc """
+  @doc ~S"""
   Creates a function that receives an argument and always returns the
   original given value.
 
   ## Example
 
-    iex> one = Sky.constant(1)
-    iex> one.(2)
-    1
-    iex> one.(nil)
-    1
+      iex> one = Sky.constant(1)
+      iex> one.(2)
+      1
+      iex> one.(nil)
+      1
   """
   def constant(value) do
     fn _ -> value end
@@ -126,11 +125,11 @@ defmodule Sky do
 
   ## Examples
 
-    iex> safe_float_div = Sky.noraise(fn ({a, b}) -> a / b end)
-    iex> safe_float_div.({1, 0})
-    {:error, %ArithmeticError{message: "bad argument in arithmetic expression"}}
-    iex> safe_float_div.({1, 2})
-    {:ok, 0.5}
+      iex> safe_float_div = Sky.noraise(fn ({a, b}) -> a / b end)
+      iex> safe_float_div.({1, 0})
+      {:error, %ArithmeticError{message: "bad argument in arithmetic expression"}}
+      iex> safe_float_div.({1, 2})
+      {:ok, 0.5}
   """
   def noraise(f) when is_function(f) do
     fn x ->
@@ -142,7 +141,7 @@ defmodule Sky do
     end
   end
 
-  @doc """
+  @doc ~S"""
   Given two one-argument functions, a subject *f* and a predicate *p*, return
   a function that takes an argument *x*.
 
@@ -150,12 +149,12 @@ defmodule Sky do
 
   ## Example
 
-    iex> f = fn x -> x - 1 end
-    iex> p = fn x -> x > 0 end
-    iex> Sky.reject_if(f, p).(1)
-    {:ok, 0}
-    iex> Sky.reject_if(f, p).(0)
-    :error
+      iex> f = fn x -> x - 1 end
+      iex> p = fn x -> x > 0 end
+      iex> Sky.reject_if(f, p).(1)
+      {:ok, 0}
+      iex> Sky.reject_if(f, p).(0)
+      :error
   """
   def reject_if(f, p) when is_function(f) and is_function(p) do
     fn x ->
@@ -163,7 +162,7 @@ defmodule Sky do
     end
   end
 
-  @doc """
+  @doc ~S"""
   Given two one-argument functions, a subject *f* and a predicate *p*, return
   a function that takes an argument *x*.
 
@@ -172,13 +171,13 @@ defmodule Sky do
 
   ## Example
 
-    iex> trim = (&tl/1)
-    iex> non_empty? = fn list -> length(list) > 0 end
-    iex> safetrim = Sky.apply_if(trim, non_empty?)
-    iex> safetrim.([1,2])
-    [2]
-    iex> safetrim.([])
-    []
+      iex> trim = (&tl/1)
+      iex> non_empty? = fn list -> length(list) > 0 end
+      iex> safetrim = Sky.apply_if(trim, non_empty?)
+      iex> safetrim.([1,2])
+      [2]
+      iex> safetrim.([])
+      []
   """
   def apply_if(f, p) when is_function(f) and is_function(p) do
     fn x ->
@@ -186,31 +185,32 @@ defmodule Sky do
     end
   end
 
-  @doc """
+  @doc ~S"""
   Given a predicate *p*, which receives a single argument and returns a
   boolean value, return a function which is equivalent to `not p.(x)`
 
   ## Example
-    iex> negative? = fn x -> x < 0 end
-    iex> no_negative? = Sky.negate(negative?)
-    iex> no_negative?.(1)
-    true
+
+      iex> negative? = fn x -> x < 0 end
+      iex> no_negative? = Sky.negate(negative?)
+      iex> no_negative?.(1)
+      true
 
   """
   def negate(p) when is_function(p) do
     fn v -> not p.(v) end
   end
 
-  @doc """
+  @doc ~S"""
   Get the arity of the given function.
 
   ## Examples
 
-    iex> Sky.arity(&Enum.map/2)
-    2
+      iex> Sky.arity(&Enum.map/2)
+      2
 
-    iex> Sky.arity(fn(_, _, _) -> nil end)
-    3
+      iex> Sky.arity(fn(_, _, _) -> nil end)
+      3
   """
   def arity(f) when is_function(f) do
     :erlang.fun_info(f)[:arity]

--- a/lib/sky.ex
+++ b/lib/sky.ex
@@ -1,9 +1,9 @@
 defmodule Sky do
-  @moduledoc ~S"""
+  @moduledoc """
   Collection of higher-oder functions not present in the standard library.
   """
 
-  @doc ~S"""
+  @doc """
   Curries the given function, starting with an optional list of given params.
 
   ## Examples
@@ -30,7 +30,7 @@ defmodule Sky do
     end
   end
 
-  @doc ~S"""
+  @doc """
   Given a function *f* with arity *n*, return a function that receives a
   single tuple of *n* elements and applies them to the original *f*.
 
@@ -50,7 +50,7 @@ defmodule Sky do
     end
   end
 
-  @doc ~S"""
+  @doc """
   Given a *single-argument* function *f*, return a new function that
   receives either a tuple in the form `{:ok, value}` which would execute
   `f.(value)`, or any other term, which would be returned without change.
@@ -84,7 +84,7 @@ defmodule Sky do
   defp flatten({:ok, value}), do: flatten(value)
   defp flatten(value), do: {:ok, value}
 
-  @doc ~S"""
+  @doc """
   Given a two argument functions, swap the order in wich the arguments
   are received.
 
@@ -100,7 +100,7 @@ defmodule Sky do
     fn(a, b) -> f.(b, a) end
   end
 
-  @doc ~S"""
+  @doc """
   Creates a function that receives an argument and always returns the
   original given value.
 
@@ -141,7 +141,7 @@ defmodule Sky do
     end
   end
 
-  @doc ~S"""
+  @doc """
   Given two one-argument functions, a subject *f* and a predicate *p*, return
   a function that takes an argument *x*.
 
@@ -162,7 +162,7 @@ defmodule Sky do
     end
   end
 
-  @doc ~S"""
+  @doc """
   Given two one-argument functions, a subject *f* and a predicate *p*, return
   a function that takes an argument *x*.
 
@@ -185,7 +185,7 @@ defmodule Sky do
     end
   end
 
-  @doc ~S"""
+  @doc """
   Given a predicate *p*, which receives a single argument and returns a
   boolean value, return a function which is equivalent to `not p.(x)`
 


### PR DESCRIPTION
Code should be 4-space indented to look right on the generated html.
Use the ~S sigil convention for docs.